### PR TITLE
Resql docker dependency fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,11 +2,12 @@ FROM openjdk:17-jdk as build
 
 WORKDIR /workspace/app
 
+ARG ID_LOG_VERSION=1.0.0-SNAPSHOT
 COPY mvnw .
 COPY .mvn .mvn
 COPY pom.xml .
 COPY src src
 COPY libs libs
 RUN mkdir templates
-RUN ./mvnw install:install-file -Dfile=libs/id-log-1.0.0-SNAPSHOT.jar -DgroupId=ee.ria.commons -DartifactId=id-log -Dversion=1.0.0 -Dpackaging=jar -DgeneratePom=true
+RUN ./mvnw install:install-file -Dfile=libs/id-log-${ID_LOG_VERSION}.jar -DgroupId=ee.ria.commons -DartifactId=id-log -Dversion=${ID_LOG_VERSION} -Dpackaging=jar -DgeneratePom=true
 ENTRYPOINT ["./mvnw","spring-boot:run"]

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ To run the application using docker run:
 docker-compose up -d
 ```
 
+If you get an error about missing dependency `id-log-1.0.0-SNAPSHOT` then run `docker-compose build` and `docker-compose up -d` again.
+
 ## Creating a WAR file
 Run the following command in your local computer / virtual server
 

--- a/README.md
+++ b/README.md
@@ -16,8 +16,6 @@ To run the application using docker run:
 docker-compose up -d
 ```
 
-If you get an error about missing dependency `id-log-1.0.0-SNAPSHOT` then run `docker-compose build` and `docker-compose up -d` again.
-
 ## Creating a WAR file
 Run the following command in your local computer / virtual server
 


### PR DESCRIPTION
Fixed dependency error in docker. Error was due to `mvn install:install-file` generating files with wrong name.
New version was tested on two different freshly installed Ubuntu virtual machines.