### PR TITLE
Revert "Bump org.springframework.boot from 2.6.7 to 3.0.0"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'org.springframework.boot' version '3.0.0'
+    id 'org.springframework.boot' version '2.6.7'
     id 'org.sonarsource.scanner.maven' version '3.9.1.2184'
     id 'org.jacoco' version '0.8.8'
     id 'maven-war-plugin' version '3.3.2'


### PR DESCRIPTION
Reverts buerokratt/Resql#12
version 3.0.0 is missing `WebSecurityConfigurerAdapter`, which is used in `SecurityConfigurer` class
Initial test was made without changes in pom.xml