### PR TITLE
22 Apply RESTful Resource Naming Convention for Resql endpoints

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:17-jdk as build
+FROM eclipse-temurin:17-jdk as build
 
 WORKDIR /workspace/app
 
@@ -8,6 +8,7 @@ COPY .mvn .mvn
 COPY pom.xml .
 COPY src src
 COPY libs libs
-RUN mkdir templates
+ENV sqlms.saved-queries-dir=/DSL
+RUN mkdir -p DSL/GET DSL/POST
 RUN ./mvnw install:install-file -Dfile=libs/id-log-${ID_LOG_VERSION}.jar -DgroupId=ee.ria.commons -DartifactId=id-log -Dversion=${ID_LOG_VERSION} -Dpackaging=jar -DgeneratePom=true
 ENTRYPOINT ["./mvnw","spring-boot:run"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,8 @@ services:
     container_name: resql
     build:
       context: .
+    volumes:
+      - ./DSL:/DSL
     ports:
       - 8082:8082
     networks:

--- a/src/main/java/rig/sqlms/controller/QueryController.java
+++ b/src/main/java/rig/sqlms/controller/QueryController.java
@@ -2,10 +2,8 @@ package rig.sqlms.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.bind.annotation.*;
 import rig.sqlms.service.QueryService;
 
 import java.util.List;
@@ -20,10 +18,21 @@ public class QueryController {
     /**
      * @return JSON array containing the results
      */
-    @Operation(description = "Initiates previously configured queries")
-    @PostMapping("/{name}")
-    public List<Map<String, Object>> execute(@PathVariable String name, @RequestBody(required = false) Map<String, Object> parameters) {
-        return queryService.execute(name, parameters);
+    @Operation(description = "Initiates previously configured POST queries")
+    @PostMapping(value = "/{name}")
+    public List<Map<String, Object>> execute(@PathVariable String name,
+                                             @RequestBody(required = false) Map<String, Object> parameters) {
+        return queryService.executePost(name, parameters);
+    }
+
+    /**
+     * @return JSON array containing the results
+     */
+    @Operation(description = "Initiates previously configured GET queries")
+    @GetMapping(value = "/{name}")
+    public List<Map<String, Object>> execute(@PathVariable String name,
+                                             @RequestParam(required = false) MultiValueMap<String, Object> parameters) {
+        return queryService.executeGet(name, parameters.toSingleValueMap());
     }
 
     /**
@@ -33,7 +42,7 @@ public class QueryController {
     @PostMapping("/{name}/batch")
     public List<List<Map<String, Object>>> executeBatch(@PathVariable String name, @RequestBody BatchRequest batchRequest) {
         return batchRequest.queries.stream()
-                .map(parameters -> queryService.execute(name, parameters))
+                .map(parameters -> queryService.executePost(name, parameters))
                 .toList();
     }
 

--- a/src/main/java/rig/sqlms/service/QueryService.java
+++ b/src/main/java/rig/sqlms/service/QueryService.java
@@ -21,8 +21,14 @@ public class QueryService {
     private final SavedQueryService savedQueryService;
     private final ResqlJdbcTemplate resqlJdbcTemplate;
 
-    public List<Map<String, Object>> execute(String queryName, Map<String, Object> parameters) {
-        SavedQuery savedQuery = savedQueryService.get(queryName);
+    public List<Map<String, Object>> executePost(String queryName, Map<String, Object> parameters) {
+        SavedQuery savedQuery = savedQueryService.get("POST", queryName);
+        setDatabaseContext(savedQuery.dataSourceName());
+        return resqlJdbcTemplate.queryOrExecute(savedQuery.query(), parameters);
+    }
+
+    public List<Map<String, Object>> executeGet(String queryName, Map<String, Object> parameters) {
+        SavedQuery savedQuery = savedQueryService.get("GET", queryName);
         setDatabaseContext(savedQuery.dataSourceName());
         return resqlJdbcTemplate.queryOrExecute(savedQuery.query(), parameters);
     }

--- a/src/main/java/rig/sqlms/service/SavedQueryService.java
+++ b/src/main/java/rig/sqlms/service/SavedQueryService.java
@@ -11,26 +11,36 @@ import rig.sqlms.model.SavedQuery;
 import java.io.File;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 @Service
 @Slf4j
 public class SavedQueryService {
-    private final Map<String, SavedQuery> savedQueries = new HashMap<>();
+
+    private final String[] METHODS = {"GET", "POST"};
+
+    private final Map<String, Map<String, SavedQuery>> savedQueries = new HashMap<>();
 
     public SavedQueryService(@Value("${sqlms.saved-queries-dir}") String savedQueriesDir) {
         log.info("Initializing SavedQueryService");
-        loadQueries(getConfigDir(savedQueriesDir).listFiles());
+        for (String method : METHODS) {
+            String queriesPath = savedQueriesDir + method + "/";
+            log.debug("Loading queries from "+ queriesPath);
+            loadQueries(method, getConfigDir(savedQueriesDir + method + "/").listFiles());
+        }
     }
 
-    private void loadQueries(File[] filesList) {
+    private void loadQueries(String method, File[] filesList) {
+        if (!savedQueries.containsKey(method))
+            savedQueries.put(method, new HashMap<>());
         try {
             if (filesList != null) {
                 for (File file : filesList) {
                     if (file.isDirectory()) {
-                        loadQueries(file.listFiles());
+                        loadQueries(method, file.listFiles());
                     } else {
                         try {
-                            savedQueries.put(getQueryName(file), SavedQuery.of(file.getAbsolutePath()));
+                            savedQueries.get(method).put(getQueryName(file), SavedQuery.of(file.getAbsolutePath()));
                         } catch (Throwable t) {
                             log.error("Failed parsing saved query file {}", file.getName(), t);
                         }
@@ -40,6 +50,8 @@ public class SavedQueryService {
         } catch (Exception e) {
             log.error("Failed loading configuration service", e);
         }
+
+        log.debug("Loaded queries: "+mapDeepToString(savedQueries));
     }
 
     private String getQueryName(File file) {
@@ -47,8 +59,8 @@ public class SavedQueryService {
     }
 
     @NonNull
-    public SavedQuery get(String name) {
-        SavedQuery query = savedQueries.get(name.trim().toLowerCase());
+    public SavedQuery get(String method, String name) {
+        SavedQuery query = savedQueries.get(method).get(name.trim().toLowerCase());
 
         if (query == null) {
             throw new ResqlRuntimeException("Saved query '%s' does not exist".formatted(name));
@@ -64,8 +76,17 @@ public class SavedQueryService {
 
         configDir = new File(path);
         if (!configDir.exists() && !configDir.isDirectory())
-            throw new InvalidDirectoryException("Saved configuration directory missing or not a directory");
+            throw new InvalidDirectoryException("Saved configuration directory missing or not a directory: " + path);
 
         return configDir;
     }
+
+    public static String mapDeepToString(Map<String, Map<String, SavedQuery>> map) {
+        return map.entrySet().stream()
+                .map(method -> "{" + method.getKey() +
+                        method.getValue().entrySet().stream().map(path -> path.getKey() + "=>" + path.getValue())
+                                .collect(Collectors.joining(",")) + "}")
+                .collect(Collectors.joining(","));
+    }
+
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -18,7 +18,7 @@ h2:
     enabled: true
 
 sqlms:
-  saved-queries-dir: "./templates/"
+  saved-queries-dir: "/DSL/"
   datasources:
     - name: test_db_1
       jdbcUrl: jdbc:h2:mem:test_db_1;DATABASE_TO_UPPER=false;DB_CLOSE_DELAY=-1


### PR DESCRIPTION
Now sql files should go to DSL/GET and DSL/POST just as in Ruuter, also GET requests are supported with variables as query parameters